### PR TITLE
Reduce heavy visual effects on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -149,6 +149,41 @@ html::after {
 }
 
 /* ================================
+   Ajustes móviles (optimización)
+===================================*/
+@media (max-width: 768px) {
+  body::before,
+  body::after,
+  html::after {
+    display: none;
+  }
+
+  header {
+    background: var(--bg-main);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    box-shadow: none;
+  }
+
+  .toggle-theme {
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.25);
+    filter: none;
+  }
+
+  .container {
+    background: none;
+    box-shadow: none;
+  }
+
+  .content,
+  .sidebar {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    box-shadow: none;
+  }
+}
+
+/* ================================
    Header
 ===================================*/
 header {


### PR DESCRIPTION
## Summary
- disable the animated background layers on narrow viewports to ease rendering on mobile devices
- remove backdrop filters and heavy shadows on mobile to reduce GPU load

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fde27d31b483279c0e91b2226a9e43