### PR TITLE
Remove prompt evaluation modal and update theme toggle icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,13 @@
 </head>
 <body>
   <button class="toggle-theme" type="button" aria-label="Cambiar tema" onclick="toggleTheme()">
-    <span aria-hidden="true">Cambiar tema</span>
+    <svg class="icon-sun" viewBox="0 0 24 24" role="img" aria-hidden="true">
+      <path d="M12 5.5a1 1 0 0 0 1-1V3a1 1 0 1 0-2 0v1.5a1 1 0 0 0 1 1Zm0 13a1 1 0 0 0-1 1V21a1 1 0 1 0 2 0v-1.5a1 1 0 0 0-1-1Zm6.5-6.5a1 1 0 0 0 1-1H21a1 1 0 1 0 0-2h-1.5a1 1 0 0 0-1 1 1 1 0 0 0 1 1ZM4.5 12a1 1 0 0 0 1-1 1 1 0 0 0-1-1H3a1 1 0 1 0 0 2h1.5Zm12.02 5.02a1 1 0 0 0 1.41 1.41l1.06-1.06a1 1 0 1 0-1.41-1.41l-1.06 1.06Zm-9.04-9.04a1 1 0 0 0 1.41-1.41L7.33 5.51a1 1 0 0 0-1.41 1.41l1.06 1.06Zm9.04-4.46 1.06 1.06a1 1 0 0 0 1.41-1.41L17.34 3.1a1 1 0 0 0-1.41 1.41ZM6.99 16.99l-1.06 1.06a1 1 0 0 0 1.41 1.41l1.06-1.06a1 1 0 1 0-1.41-1.41ZM12 8a4 4 0 1 0 0 8 4 4 0 0 0 0-8Z" />
+    </svg>
+    <svg class="icon-moon" viewBox="0 0 24 24" role="img" aria-hidden="true">
+      <path d="M21 12.8A9 9 0 0 1 11.2 3 7 7 0 1 0 21 12.8Z" />
+    </svg>
+    <span class="sr-only">Cambiar tema</span>
   </button>
 
   <header class="hero" role="banner">
@@ -69,7 +75,7 @@
               <h3>Profundiza con confianza</h3>
               <ul>
                 <li>Bloques expandibles con ejemplos avanzados y estudios de caso.</li>
-                <li>Modal “Evaluar mi prompt” con checklist rápida y enlaces a herramientas externas.</li>
+              <li>Recursos descargables con rúbricas y checklists complementarias.</li>
                 <li>Encuesta de cierre con iconos de caritas para recoger feedback.</li>
               </ul>
             </div>
@@ -80,32 +86,6 @@
   </div>
 
   <button id="readerToggle" class="reader-toggle" type="button" aria-pressed="false">Modo lectura</button>
-  <button id="evaluateBtn" class="evaluate-btn" type="button">Evaluar mi prompt</button>
-
-  <div id="evaluationModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="modalTitle" hidden>
-    <div class="modal-dialog">
-      <header class="modal-header">
-        <h2 id="modalTitle">Checklist rápida</h2>
-        <button type="button" class="modal-close" aria-label="Cerrar" data-close-modal>&times;</button>
-      </header>
-      <div class="modal-content">
-        <p>Valida tu prompt antes de ejecutarlo:</p>
-        <ul class="modal-checklist">
-          <li><input type="checkbox" id="chk-objetivo" /><label for="chk-objetivo">El objetivo está descrito en una frase accionable.</label></li>
-          <li><input type="checkbox" id="chk-contexto" /><label for="chk-contexto">Incluí contexto, formato y tono esperados.</label></li>
-          <li><input type="checkbox" id="chk-seguridad" /><label for="chk-seguridad">Consideré implicaciones éticas y de seguridad.</label></li>
-        </ul>
-        <div class="modal-links">
-          <a href="assets/checklist-sesion.md">Checklist completa de sesión</a>
-          <a href="assets/rubricas/evaluacion.csv">Rúbrica de métricas</a>
-        </div>
-      </div>
-      <footer class="modal-footer">
-        <button type="button" class="btn btn-primary" data-close-modal>Listo</button>
-      </footer>
-    </div>
-  </div>
-
   <section class="feedback" aria-labelledby="feedbackTitle">
     <h2 id="feedbackTitle">Cuéntanos cómo te fue</h2>
     <form class="feedback-form">

--- a/script.js
+++ b/script.js
@@ -20,10 +20,22 @@
     landingHTML: ""
   };
 
+  function syncThemeToggle() {
+    const root = document.documentElement;
+    const isDark = root.getAttribute("data-theme") === "dark";
+    const button = $(".toggle-theme");
+    if (!button) return;
+    const label = isDark ? "Cambiar a tema claro" : "Cambiar a tema oscuro";
+    button.setAttribute("aria-label", label);
+    const srOnly = button.querySelector(".sr-only");
+    if (srOnly) srOnly.textContent = label;
+  }
+
   window.toggleTheme = function toggleTheme() {
     const root = document.documentElement;
     const cur = root.getAttribute("data-theme") === "dark" ? "dark" : "light";
     root.setAttribute("data-theme", cur === "light" ? "dark" : "light");
+    syncThemeToggle();
   };
 
   const hexToRgba = (hex, alpha = 1) => {
@@ -563,32 +575,6 @@
     });
   }
 
-  function setupModal() {
-    const btn = $("#evaluateBtn");
-    const modal = $("#evaluationModal");
-    if (!btn || !modal) return;
-    const close = () => {
-      modal.hidden = true;
-      modal.setAttribute("aria-hidden", "true");
-    };
-    btn.addEventListener("click", () => {
-      modal.hidden = false;
-      modal.removeAttribute("aria-hidden");
-      const firstInput = modal.querySelector("input, button");
-      firstInput?.focus();
-    });
-    modal.addEventListener("click", (event) => {
-      if (event.target === modal || event.target.hasAttribute("data-close-modal")) {
-        close();
-      }
-    });
-    document.addEventListener("keydown", (event) => {
-      if (event.key === "Escape" && !modal.hidden) {
-        close();
-      }
-    });
-  }
-
   function setupShortcuts() {
     document.addEventListener("keydown", (event) => {
       if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey) return;
@@ -622,8 +608,8 @@
       setupReaderToggle();
       setupCTA();
       setupCopy();
-      setupModal();
       setupShortcuts();
+      syncThemeToggle();
     } catch (error) {
       console.error(error);
       const content = $("#content");

--- a/style.css
+++ b/style.css
@@ -109,6 +109,40 @@ button {
   box-shadow: var(--shadow-hover);
 }
 
+.toggle-theme svg {
+  width: 22px;
+  height: 22px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+}
+
+.toggle-theme .icon-moon {
+  display: none;
+  fill: currentColor;
+  stroke: none;
+}
+
+[data-theme="dark"] .toggle-theme .icon-sun {
+  display: none;
+}
+
+[data-theme="dark"] .toggle-theme .icon-moon {
+  display: inline;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .hero {
   display: grid;
   gap: 2rem;
@@ -192,8 +226,8 @@ button {
 
 .btn-link {
   box-shadow: none;
-  padding-left: 0;
-  padding-right: 0;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
   border-width: 0;
   gap: 0.4rem;
 }
@@ -733,21 +767,6 @@ button {
   margin-top: 2rem;
 }
 
-.evaluate-btn {
-  position: fixed;
-  bottom: 1.5rem;
-  right: 1.5rem;
-  background: var(--color-success);
-  color: #FFFFFF;
-  border-radius: var(--radius-button);
-  border: 4px solid rgba(255, 255, 255, 0.3);
-  padding: 0.9rem 1.6rem;
-  font-weight: 700;
-  box-shadow: var(--shadow-hover);
-  cursor: pointer;
-  z-index: 25;
-}
-
 .reader-toggle {
   position: fixed;
   bottom: 1.5rem;
@@ -782,61 +801,6 @@ button {
 
 .focus-mode .content {
   box-shadow: 0 0 0 3px rgba(255, 207, 68, 0.45), var(--shadow-soft);
-}
-
-.modal {
-  position: fixed;
-  inset: 0;
-  background: rgba(15, 26, 35, 0.6);
-  display: grid;
-  place-items: center;
-  padding: 1.5rem;
-  z-index: 40;
-}
-
-.modal-dialog {
-  background: var(--color-surface);
-  color: var(--color-text);
-  border-radius: var(--radius-card);
-  box-shadow: var(--shadow-hover);
-  width: min(420px, 100%);
-  display: grid;
-  gap: 1rem;
-  padding: 1.5rem;
-}
-
-.modal-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  border-bottom: 1px solid rgba(31, 59, 77, 0.12);
-  padding-bottom: 0.5rem;
-}
-
-.modal-close {
-  background: none;
-  border: none;
-  font-size: 1.4rem;
-  cursor: pointer;
-}
-
-.modal-checklist {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: grid;
-  gap: 0.6rem;
-}
-
-.modal-checklist input {
-  margin-right: 0.5rem;
-}
-
-.modal-links {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  font-size: 0.9rem;
 }
 
 .feedback {
@@ -925,7 +889,6 @@ button {
     position: static;
   }
 
-  .evaluate-btn,
   .reader-toggle {
     bottom: 1rem;
     right: auto;


### PR DESCRIPTION
## Summary
- replace the theme toggle text with sun and moon icons and keep the accessible label in sync with the active theme
- remove the unused "Evaluar mi prompt" button, checklist modal markup, and related scripts/styles
- adjust hero card link button padding to improve left spacing

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68fdfa8fe16c832786539256aac1aca9